### PR TITLE
refactor: add tableCell attributes type

### DIFF
--- a/packages/fluent-editor/src/table/formats/table.ts
+++ b/packages/fluent-editor/src/table/formats/table.ts
@@ -60,7 +60,7 @@ class TableCellLine extends Block {
     if (formats['list']) {
       formats['list'] = domNode.classList.item(0);
     }
-    return reduceFormats(domNode, formats, ['cell-bg']);
+    return reduceFormats(domNode, formats);
   }
 
   toggleAttribute(name, value) {
@@ -1217,8 +1217,8 @@ function cellId() {
   return `cell-${id}`;
 }
 
-function reduceFormats(domNode:HTMLElement, formats:Record<string, any>, extraFormat: string[] = []) {
-  return [...CELL_ATTRIBUTES, ...CELL_IDENTITY_KEYS, ...extraFormat].reduce((tableFormats, attribute) => {
+function reduceFormats(domNode:HTMLElement, formats:Record<string, any>) {
+  return [...CELL_ATTRIBUTES, ...CELL_IDENTITY_KEYS].reduce((tableFormats, attribute) => {
     if (domNode.hasAttribute(`data-${attribute}`)) {
       tableFormats[attribute] = domNode.getAttribute(`data-${attribute}`) || undefined;
     }

--- a/packages/fluent-editor/src/table/formats/table.ts
+++ b/packages/fluent-editor/src/table/formats/table.ts
@@ -43,7 +43,7 @@ class TableCellLine extends Block {
       node.setAttribute(`data-${key}`, value[key] || identityMaker());
     });
 
-    [...CELL_ATTRIBUTES, 'cell-bg'].forEach((attrName) => {
+    CELL_ATTRIBUTES.forEach((attrName) => {
       const keyValue = value[attrName] || CELL_DEFAULT[attrName];
       keyValue && node.setAttribute(`data-${attrName}`, keyValue);
     });

--- a/packages/fluent-editor/src/table/table-config.ts
+++ b/packages/fluent-editor/src/table/table-config.ts
@@ -21,7 +21,7 @@ export const COL_DEFAULT = {
   width: 100
 };
 export const CELL_IDENTITY_KEYS = ['row', 'cell'];
-export const CELL_ATTRIBUTES = ['rowspan', 'colspan'];
+export const CELL_ATTRIBUTES = ['rowspan', 'colspan', 'cell-bg'];
 export const CELL_DEFAULT = {
   rowspan: 1,
   colspan: 1


### PR DESCRIPTION
base [PR#10](https://github.com/opentiny/fluent-editor/pull/10) refactor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added a new `cell-bg` attribute for enhanced table cell styling options.
- **Improvements**
	- Updated cell attribute processing to streamline how attributes are managed, focusing exclusively on defined cell attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->