### PR TITLE
fix: toolbar video button can't insert video correctly

### DIFF
--- a/packages/fluent-editor/src/link/modules/tooltip.ts
+++ b/packages/fluent-editor/src/link/modules/tooltip.ts
@@ -187,7 +187,9 @@ export default class Tooltip extends BaseTooltip {
   }
 
   save() {
-    let { value } = this.textbox;
+    let value = this.textbox.value;
+    if (!value) return
+    this.textbox.value = '';
     switch (this.root.getAttribute('data-mode')) {
     case 'link': {
       const { scrollTop } = this.quill.root;
@@ -212,9 +214,6 @@ export default class Tooltip extends BaseTooltip {
       break;
     }
     case 'formula': {
-      if (!value) {
-        break;
-      }
       const range = this.quill.getSelection(true);
       if (!isNullOrUndefined(range)) {
         const index = range.index + range.length;
@@ -229,6 +228,16 @@ export default class Tooltip extends BaseTooltip {
         }
         this.quill.setSelection(index + 2, Emitter.sources.USER);
       }
+      break;
+    }
+    case 'video': {
+      const range = this.quill.getSelection(true);
+      this.quill.insertText(range.index , '\n', Emitter.sources.USER);
+      this.quill.insertEmbed(range.index+ 1, 'video', { src: value }, Emitter.sources.USER)
+      this.quill.insertText(range.index + 2, '\n', Emitter.sources.USER);
+      this.quill.setSelection(range.index + 3, Emitter.sources.SILENT);
+      this.textbox.value = '';
+      this.hide()
       break;
     }
     default:

--- a/packages/fluent-editor/src/video/index.ts
+++ b/packages/fluent-editor/src/video/index.ts
@@ -2,10 +2,10 @@ import Quill from 'quill';
 import { sanitize } from '../config/editor.utils';
 
 
-const Embed = Quill.imports['blots/embed'];
+const BlockEmbed = Quill.imports['blots/block/embed'];
 const VIDEO_ATTRIBUTES = ['id', 'title', 'src'];
 
-class Video extends Embed {
+class Video extends BlockEmbed {
   static blotName: string;
   static tagName: string;
   static SANITIZED_URL: string;
@@ -41,17 +41,6 @@ class Video extends Embed {
   }
 
   static value(domNode) {
-    const formats: any = {};
-    VIDEO_ATTRIBUTES.forEach(key => {
-      const value = domNode.getAttribute(key) || domNode.dataset[key];
-      if (value) {
-        formats[key] = value;
-      }
-    });
-    return formats;
-  }
-
-  static formats(domNode) {
     const formats: any = {};
     VIDEO_ATTRIBUTES.forEach(key => {
       const value = domNode.getAttribute(key) || domNode.dataset[key];

--- a/packages/fluent-editor/src/video/index.ts
+++ b/packages/fluent-editor/src/video/index.ts
@@ -1,8 +1,9 @@
 import Quill from 'quill';
+import type { Parchment as TypeParchment } from 'quill';
 import { sanitize } from '../config/editor.utils';
 
 
-const BlockEmbed = Quill.imports['blots/block/embed'];
+const BlockEmbed = Quill.imports['blots/block/embed'] as TypeParchment.BlotConstructor;
 const VIDEO_ATTRIBUTES = ['id', 'title', 'src'];
 
 class Video extends BlockEmbed {
@@ -19,16 +20,16 @@ class Video extends BlockEmbed {
   }
 
   static create(value) {
-    const node = super.create(value);
-    node.setAttribute('contenteditable', false);
+    const node = super.create(value) as HTMLElement;
+    node.setAttribute('contenteditable', 'false');
     node.setAttribute('controls', 'controls');
     VIDEO_ATTRIBUTES.forEach(key => {
       if (value[key]) {
         switch (key) {
         case 'src':
-        { const src = Video.sanitize(value[key]);
+          const src = Video.sanitize(value[key]);
           node.setAttribute(key, src);
-          break;}
+          break;
         case 'title':
           node.setAttribute(key, value[key]);
           break;


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our Commit Message Guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #17 

## What is the new behavior?

after input video src and press enter will insert video correctly

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

remove unnecessary video attributes in delta.

change video blot type to `BlockEmbed`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved input validation in the Tooltip for enhanced user experience.
	- Added functionality to embed video content directly within the editor.

- **Bug Fixes**
	- Simplified logic for handling empty values in the Tooltip's save method.

- **Refactor**
	- Changed the Video class to extend BlockEmbed for better handling of video elements.
	- Removed the redundant formats method from the Video class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->