### PR TITLE
build: adjust build dist and move quill to dependencies

### DIFF
--- a/packages/docs/fluent-editor/docs/quick-start.md
+++ b/packages/docs/fluent-editor/docs/quick-start.md
@@ -1,9 +1,9 @@
 # 快速开始
 
-安装 Fluent Editor 和 Quill：
+安装 Fluent Editor：
 
 ```shell
-npm i @opentiny/fluent-editor quill
+npm i @opentiny/fluent-editor
 ```
 
 编写 html：

--- a/packages/docs/fluent-editor/vite.config.ts
+++ b/packages/docs/fluent-editor/vite.config.ts
@@ -8,12 +8,8 @@ export default defineConfig({
   resolve: {
     alias: [
       {
-        find: /^@opentiny\/fluent-editor(\/(es|lib))?$/,
-        replacement: path.resolve(fluentEditorRoot, 'src/index.ts'),
-      },
-      {
-        find: /^@opentiny\/fluent-editor\/(theme)\/(.*)$/,
-        replacement: `${path.resolve(fluentEditorRoot, 'src/assets')}/$1/$2`,
+        find: '@opentiny/fluent-editor/style.scss',
+        replacement: path.resolve(fluentEditorRoot, 'src/assets/style.scss'),
       },
     ],
   },

--- a/packages/fluent-editor/package.json
+++ b/packages/fluent-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/fluent-editor",
-  "version": "3.20.0",
+  "version": "3.20.2",
   "description": "A rich text editor based on Quill 2.0, which extends rich modules and formats on the basis of Quill. It's powerful and out-of-the-box.",
   "author": "OpenTiny Team",
   "license": "MIT",
@@ -22,27 +22,18 @@
     "opentiny",
     "fluent-editor"
   ],
-  "exports": {
-    ".": {
-      "import": "./src/index.ts",
-      "require": "./src/index.ts"
-    },
-    "./style.scss": "./src/assets/style.scss"
-  },
   "main": "src/index.ts",
   "module": "src/index.ts",
   "scripts": {
     "start": "vite build && vite",
     "dev": "vite",
-    "build": "vite build && pnpm build:theme && node scripts/pre-release.js",
+    "build": "pnpm build:theme && vite build && node scripts/pre-release.js",
     "build:theme": "vite build --config vite.config.theme.ts",
     "test": "jest"
   },
-  "peerDependencies": {
-    "quill": "^2.0.0"
-  },
   "dependencies": {
-    "lodash-es": "^4.17.15"
+    "lodash-es": "^4.17.15",
+    "quill": "^2.0.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.23",

--- a/packages/fluent-editor/scripts/pre-release.js
+++ b/packages/fluent-editor/scripts/pre-release.js
@@ -24,15 +24,10 @@ if (program.versions) {
   newVersion = program.versions
 }
 
-console.log('newVersion:', newVersion)
-
 function preRelease() {
   shelljs.sed('-i', `"version": "${currentVersion}"`, `"version": "${newVersion}"`, targetFile)
   shelljs.sed('-i', `"main": "src/index.ts"`, `"main": "lib/index.cjs.js"`, targetFile)
   shelljs.sed('-i', `"module": "src/index.ts"`, `"module": "es/index.es.js"`, targetFile)
-  shelljs.sed('-i', `"import": "./src/index.ts"`, `"import": "./es/index.es.js"`, targetFile)
-  shelljs.sed('-i', `"require": "./src/index.ts"`, `"require": "./lib/index.cjs.js"`, targetFile)
-  shelljs.sed('-i', `"./style.scss": "./src/assets/style.scss"`, `"./style.css": "./theme/style.css"`, targetFile)
   shelljs.cp('-rf', '../../README.md', 'dist')
 }
 

--- a/packages/fluent-editor/vite.config.theme.ts
+++ b/packages/fluent-editor/vite.config.theme.ts
@@ -10,7 +10,7 @@ export default defineConfig({
       treeshake: false,
       preserveEntrySignatures: 'strict',
       output: {
-        dir: resolve(__dirname, 'dist/theme'),
+        dir: resolve(__dirname, 'dist'),
         assetFileNames: 'style.css',
         preserveModules: true,
         preserveModulesRoot: resolve(__dirname, 'src/assets'),


### PR DESCRIPTION
# PR

主要更新：

1. 将 quill 从 peerDependencies 中移到 dependencies 中，这样用户就不需要手动安装 quill，quill 应该作为 fluent-editor 的间接依赖存在
2. 将产物中的 theme/style.css 平铺到 style.css，并移除对应 package.json 中的 exports 配置，以及 pre-release 脚本中对应的代码

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our Commit Message Guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the Fluent Editor's Vite configuration for improved style handling.
	- Simplified installation instructions in the quick start documentation.

- **Bug Fixes**
	- Removed unnecessary console logs from the pre-release script.

- **Chores**
	- Updated version number from 3.20.0 to 3.20.2.
	- Changed dependency management for `quill` from peer to a direct dependency.
	- Adjusted the build output directory for theme files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->