### PR TITLE
fix: only display warn when lang is not config

### DIFF
--- a/packages/fluent-editor/src/config/editor.config.ts
+++ b/packages/fluent-editor/src/config/editor.config.ts
@@ -8,6 +8,7 @@ export const LANG_CONF = {
   'zh-CN': ZH_CN,
 }
 export const CHANGE_LANGUAGE_EVENT = 'change-language'
+export const defaultLanguage = 'en-US'
 
 // Image
 export const IMAGE_UPLOADER_MIME_TYPES = [

--- a/packages/fluent-editor/src/fluent-editor.ts
+++ b/packages/fluent-editor/src/fluent-editor.ts
@@ -2,7 +2,7 @@ import type { ExpandedQuillOptions, Module, Parchment as TypeParchment } from 'q
 import type { IEditorConfig } from './config/types'
 import Quill from 'quill'
 import { FontStyle, LineHeightStyle, SizeStyle, TextIndentStyle } from './attributors'
-import { CHANGE_LANGUAGE_EVENT, getListValue, ICONS_CONFIG, inputFile, LANG_CONF } from './config'
+import { CHANGE_LANGUAGE_EVENT, defaultLanguage, getListValue, ICONS_CONFIG, inputFile, LANG_CONF } from './config'
 import Counter from './counter' // 字符统计
 import CustomClipboard from './custom-clipboard' // 粘贴板
 import CustomImage from './custom-image/BlotFormatter' // 图片
@@ -22,6 +22,7 @@ import Strike from './strike' // 删除线
 import CustomSyntax from './syntax' // 代码块高亮
 import BetterTable from './table/better-table' // 表格
 import Toolbar from './toolbar' // 工具栏
+import { isUndefined } from './utils/is'
 import Video from './video' // 视频
 // import GlobalLink from './global-link' // 全局链接
 // import QuickMenu from './quick-menu' // 快捷菜单
@@ -30,9 +31,12 @@ export interface I18NOptions {
   langText: Record<string, string>
 }
 function resolveLanguageOption(options: Partial<I18NOptions>): I18NOptions {
+  if (isUndefined(options.lang)) {
+    options.lang = defaultLanguage
+  }
   if (!(options.lang in LANG_CONF)) {
     console.warn(`The language ${options.lang} is not supported. Use the default language: en-US`)
-    options.lang = 'en-US'
+    options.lang = defaultLanguage
   }
   return {
     lang: options.lang,

--- a/packages/fluent-editor/src/fluent-editor.ts
+++ b/packages/fluent-editor/src/fluent-editor.ts
@@ -35,7 +35,7 @@ function resolveLanguageOption(options: Partial<I18NOptions>): I18NOptions {
     options.lang = defaultLanguage
   }
   if (!(options.lang in LANG_CONF)) {
-    console.warn(`The language ${options.lang} is not supported. Use the default language: en-US`)
+    console.warn(`The language ${options.lang} is not supported. Use the default language: ${defaultLanguage}`)
     options.lang = defaultLanguage
   }
   return {

--- a/packages/fluent-editor/src/utils/debounce.ts
+++ b/packages/fluent-editor/src/utils/debounce.ts
@@ -1,4 +1,5 @@
-import { isObject, root } from './method'
+import { isObject } from './is'
+import { root } from './method'
 
 export function debounce(func, wait, options = undefined) {
   let lastArgs,

--- a/packages/fluent-editor/src/utils/is.ts
+++ b/packages/fluent-editor/src/utils/is.ts
@@ -1,0 +1,5 @@
+export function isObject(value): value is object {
+  const type = typeof value
+  return value != null && (type === 'object' || type === 'function')
+}
+export const isUndefined = (val: unknown): val is undefined => val === undefined

--- a/packages/fluent-editor/src/utils/method.ts
+++ b/packages/fluent-editor/src/utils/method.ts
@@ -20,11 +20,6 @@ const freeSelf
 export const root
   = freeGlobalThis || freeGlobal || freeSelf || new Function('return this')()
 
-export function isObject(value) {
-  const type = typeof value
-  return value != null && (type === 'object' || type === 'function')
-}
-
 export function compareArray(arr1, arr2) {
   if (arr1.length !== arr2.length) {
     return false


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our Commit Message Guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

default language warn should not display when `options.lang` is not configured

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a default language configuration for the editor, defaulting to 'en-US'.
	- Enhanced language handling to ensure consistent fallback behavior when an unsupported language is provided.

- **Bug Fixes**
	- Improved logic for resolving language options, ensuring the editor initializes with the correct language settings.

- **Documentation**
	- Added new utility functions to check for object types and undefined values, improving code clarity.

- **Chores**
	- Cleaned up imports in utility files without affecting core functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->