### PR TITLE
fix: mathlive formula should not display edit dialog when quill disabled

### DIFF
--- a/packages/fluent-editor/src/assets/mathlive.scss
+++ b/packages/fluent-editor/src/assets/mathlive.scss
@@ -12,9 +12,9 @@
 }
 
 .ql-tooltip.math-field-tooltip {
-  border: none !important;
-  z-index: 10 !important;
-  padding: 0 !important;
+  border: none;
+  z-index: 10;
+  padding: 0;
 
   &::before {
     display: none;

--- a/packages/fluent-editor/src/fluent-editor.ts
+++ b/packages/fluent-editor/src/fluent-editor.ts
@@ -78,6 +78,7 @@ const registerModules = function () {
         handlers: {
           ...(SnowTheme.DEFAULTS as Record<string, any>).modules.toolbar.handlers,
           'formula': function () {
+            if (!this.quill.isEnabled()) return
             const mathlive = this.quill.getModule('mathlive')
             if (!mathlive) {
               this.quill.theme.tooltip.edit('formula')

--- a/packages/fluent-editor/src/mathlive/formats.ts
+++ b/packages/fluent-editor/src/mathlive/formats.ts
@@ -8,16 +8,7 @@ export default class MathliveBlot extends Parchment.EmbedBlot {
   static blotName = 'mathlive'
   static tagName = 'math-field'
   static className = 'ql-math-field'
-  quill?: Quill
-  initFlag = false
   mode: MathliveBlotMode
-  constructor(scroll: Root, domNode: Node) {
-    super(scroll, domNode)
-    const dom = domNode as HTMLElement
-    dom.setAttribute('contenteditable', 'false')
-    this.mode = (dom.getAttribute('mode')
-      || 'only-read') as MathliveBlotMode
-  }
 
   static create(obj: { value: string, mode: MathliveBlotMode }) {
     const el = super.create() as MathfieldElement
@@ -25,7 +16,7 @@ export default class MathliveBlot extends Parchment.EmbedBlot {
     el.classList.add('view')
     el.innerHTML = obj.value
     el.setValue(obj.value)
-    return el as MathfieldElement
+    return el
   }
 
   static value(domNode: MathfieldElement) {
@@ -35,40 +26,14 @@ export default class MathliveBlot extends Parchment.EmbedBlot {
     }
   }
 
-  value() {
-    this.init()
-    return super.value()
-  }
-
-  init() {
-    if (this.initFlag) return
-    if (this.mode === 'only-read') return
-    this.initFlag = true
-    const dom = this.domNode as MathfieldElement
-    this.quill = this.findQuillInstance()
-    if (this.mode === 'dialog') {
-      dom.addEventListener('click', () => {
-        // @ts-ignore
-        this.quill.getModule('mathlive').createDialog(dom.value)
-      })
-    }
+  constructor(scroll: Root, public domNode: MathfieldElement) {
+    super(scroll, domNode)
+    domNode.setAttribute('contenteditable', 'false')
+    this.mode = (domNode.getAttribute('mode') || 'only-read') as MathliveBlotMode
   }
 
   html() {
-    const formula = (this.domNode as MathfieldElement).value
+    const formula = this.domNode.value
     return `<math-field class="ql-math-field view" contenteditable="false" mode="${this.mode}">${formula}</math-field>`
-  }
-
-  findQuillInstance(): Quill {
-    if (this.quill) return this.quill
-    let dom = (this.domNode as HTMLElement).parentElement
-    while (dom) {
-      const quill = (dom as any).quill
-      if (quill instanceof Quill) {
-        return quill
-      }
-      dom = dom.parentElement
-    }
-    throw new Error('not found quill instance')
   }
 }

--- a/packages/fluent-editor/src/mathlive/index.ts
+++ b/packages/fluent-editor/src/mathlive/index.ts
@@ -1,17 +1,33 @@
-import type Quill from 'quill'
-import { Module } from 'quill'
+import Quill from 'quill'
+import MathliveBlot from './formats'
 import MathliveTooltip from './tooltip'
 
-export default class MathliveModule extends Module<boolean> {
+export default class MathliveModule {
   tooltip: MathliveTooltip
-  constructor(quill: Quill, options?: boolean) {
-    super(quill, options)
-    // @ts-ignore
-    quill.root.quill = quill
+  constructor(public quill: Quill) {
     this.tooltip = new MathliveTooltip(quill)
+
+    this.quill.root.addEventListener(
+      'click',
+      (e: MouseEvent) => {
+        if (!this.quill.isEnabled()) return
+        const path = e.composedPath() as HTMLElement[]
+        if (!path || path.length <= 0) return
+
+        const mathliveNode = path.find(node => node.tagName && node.tagName.toUpperCase() === MathliveBlot.tagName.toUpperCase() && node.classList.contains(MathliveBlot.className))
+        const mathliveBlot = Quill.find(mathliveNode) as MathliveBlot | null
+        if (mathliveBlot) {
+          const { value, mode } = MathliveBlot.value(mathliveBlot.domNode)
+          if (mode === 'dialog') {
+            this.createDialog(value)
+          }
+        }
+      },
+      true,
+    )
   }
 
-  async createDialog(value?: string) {
+  createDialog(value?: string) {
     this.tooltip.edit(value)
   }
 }

--- a/packages/fluent-editor/src/mathlive/tooltip.ts
+++ b/packages/fluent-editor/src/mathlive/tooltip.ts
@@ -1,10 +1,10 @@
 import type { MathfieldElement } from 'mathlive'
-import type Quill from 'quill'
 import type { Bounds } from 'quill/core/selection'
-import { Delta } from 'quill/core'
-import Emitter from 'quill/core/emitter'
-import Tooltip from 'quill/ui/tooltip'
+import type TypeTooltip from 'quill/ui/tooltip'
+import Quill from 'quill'
 
+const Delta = Quill.import('delta')
+const Tooltip = Quill.import('ui/tooltip') as typeof TypeTooltip
 export default class MathliveTooltip extends Tooltip {
   static TEMPLATE = ``
 
@@ -69,8 +69,8 @@ export default class MathliveTooltip extends Tooltip {
       .retain(index)
       .delete(this.editValue ? 1 : range?.length || 0)
       .insert({ mathlive: { value: inputValue, mode: 'dialog' } })
-    this.quill.updateContents(delta, Emitter.sources.USER)
-    this.quill.setSelection(index + 1, Emitter.sources.USER)
+    this.quill.updateContents(delta, Quill.sources.USER)
+    this.quill.setSelection(index + 1, Quill.sources.SILENT)
     this.hide()
   }
 


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our Commit Message Guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced event handling in the Mathlive module for improved user interaction.
	- Simplified dialog creation process within the Mathlive module.
	- Added checks to ensure the Quill editor is enabled before executing certain functionalities.

- **Bug Fixes**
	- Streamlined tooltip functionality by correcting import structures and method references.

- **Refactor**
	- Simplified class structures and constructors for MathliveBlot and MathliveModule.
	- Removed unnecessary complexity from the MathliveTooltip and Mathlive classes.
	- Improved language handling in the FluentEditor class.

- **Style**
	- Updated styling rules for tooltips to improve CSS specificity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->