### PR TITLE
docs: set toolbar-tip tipHoverable to false

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
     "fluent-editor"
   ],
   "scripts": {
-    "dev": "pnpm -F fluent-editor-docs dev",
-    "build": "pnpm -F fluent-editor-docs build",
+    "dev": "pnpm -F docs dev",
+    "build": "pnpm -F docs build",
     "build:lib": "pnpm -F @opentiny/fluent-editor build",
     "lint": "eslint . --cache",
     "lint:fix": "eslint . --fix",
-    "install:browser": "pnpm -F fluent-editor-docs install:browser",
-    "test": "pnpm -F fluent-editor-docs test",
-    "report": "pnpm -F fluent-editor-docs report"
+    "install:browser": "pnpm -F docs install:browser",
+    "test": "pnpm -F docs test",
+    "report": "pnpm -F docs report"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^3.9.1",

--- a/packages/docs/fluent-editor/demos/toolbar-tip.vue
+++ b/packages/docs/fluent-editor/demos/toolbar-tip.vue
@@ -54,8 +54,8 @@ onMounted(() => {
         'syntax': true,
         'toolbar-tip': {
           defaultTooltipOptions: {
-            tipHoverable: false
-          }
+            tipHoverable: false,
+          },
         },
       },
     })

--- a/packages/docs/fluent-editor/demos/toolbar-tip.vue
+++ b/packages/docs/fluent-editor/demos/toolbar-tip.vue
@@ -52,7 +52,11 @@ onMounted(() => {
         'file': true,
         'emoji-toolbar': true,
         'syntax': true,
-        'toolbar-tip': true,
+        'toolbar-tip': {
+          defaultTooltipOptions: {
+            tipHoverable: false
+          }
+        },
       },
     })
   })

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fluent-editor-docs",
+  "name": "docs",
   "type": "module",
   "version": "0.0.0",
   "private": true,
@@ -19,7 +19,7 @@
     "mathlive": "^0.101.0",
     "quill-header-list": "0.0.2",
     "quill-markdown-shortcuts": "^0.0.10",
-    "quill-toolbar-tip": "^0.0.6",
+    "quill-toolbar-tip": "^0.0.7",
     "vue": "^3.5.13",
     "vue-toastification": "2.0.0-rc.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^0.0.10
         version: 0.0.10
       quill-toolbar-tip:
-        specifier: ^0.0.6
-        version: 0.0.6(quill@2.0.3)
+        specifier: ^0.0.7
+        version: 0.0.7(quill@2.0.3)
       vue:
         specifier: ^3.5.13
         version: 3.5.13(typescript@5.4.2)
@@ -3735,8 +3735,8 @@ packages:
   quill-markdown-shortcuts@0.0.10:
     resolution: {integrity: sha512-2FFFqqo65JgDgAGSer7cFQTCeiSjJF4N8lRGXGv/xjppCxSwj42OnNdGPZ/zeeCxdUY/j1LW4AiSvPQaTIkY2A==}
 
-  quill-toolbar-tip@0.0.6:
-    resolution: {integrity: sha512-rFdqiU57oqA+McLCvbTjHxxW0FlyUJPJu2kFPE/DX35gXchV2JM/IHO+QKJJ7yHjvPpK/EOq9+HIH0nCNmqH+Q==}
+  quill-toolbar-tip@0.0.7:
+    resolution: {integrity: sha512-dD3qMLAI0ZVQFdHP2ZxOAydwDnqN6tbKsvtBhieOF47vjYnbgCCeMU5PXgSVYNlknxYoeBuUrlkqTLZyyJCA7g==}
     peerDependencies:
       quill: ^2.0.0
 
@@ -8936,7 +8936,7 @@ snapshots:
     dependencies:
       quill: 1.3.7
 
-  quill-toolbar-tip@0.0.6(quill@2.0.3):
+  quill-toolbar-tip@0.0.7(quill@2.0.3):
     dependencies:
       '@floating-ui/dom': 1.6.12
       quill: 2.0.3


### PR DESCRIPTION
# PR

之前鼠标移到提示上时，提示未隐藏，这样会导致一个问题：
- 当提示工具栏折行时，鼠标移到下面一行的工具栏图标A上，这时出现提示，我想再移到A上方的工具栏图标B上面，直接鼠标往上移动是不行的，因为会移到提示上面，而提示遮挡住了工具栏图标B。
- 需要先要移到别处，让提示消失，然后小心翼翼地移到图标B上。

优化后，不管鼠标怎么移动，都能看到提示。

优化前效果：
![toolbat-tip效果](https://github.com/user-attachments/assets/aee0fb47-d532-4a06-b6cd-0f8260fe49cb)

优化后效果：
![toolbat-tip效果-优化后](https://github.com/user-attachments/assets/b230f8d4-21d3-4b5d-ac5f-b083873e327f)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our Commit Message Guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
