### PR TITLE
docs: add readonly mode

### DIFF
--- a/packages/docs/fluent-editor/.vitepress/sidebar.ts
+++ b/packages/docs/fluent-editor/.vitepress/sidebar.ts
@@ -25,6 +25,7 @@ export function sidebar() {
         { text: '国际化', link: '/docs/demo/i18n' },
         { text: '标题列表', link: '/docs/demo/header-list' },
         { text: '工具栏提示', link: '/docs/demo/toolbar-tip' },
+        { text: '只读模式', link: '/docs/demo/readonly' },
       ],
     },
     {

--- a/packages/docs/fluent-editor/demos/readonly.vue
+++ b/packages/docs/fluent-editor/demos/readonly.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { onMounted } from 'vue'
+
+let editor
+
+onMounted(() => {
+  // ssr compat, reference: https://vitepress.dev/guide/ssr-compat#importing-in-mounted-hook
+  import('@opentiny/fluent-editor').then((module) => {
+    const FluentEditor = module.default
+
+    editor = new FluentEditor('#editor-readonly', {
+      theme: 'snow',
+      modules: {
+        toolbar: false
+      },
+      readOnly: true
+    })
+  })
+})
+</script>
+
+<template>
+  <div id="editor-readonly">
+    <p>Hello <strong>Fluent Editor</strong>!</p>
+  </div>
+</template>

--- a/packages/docs/fluent-editor/demos/readonly.vue
+++ b/packages/docs/fluent-editor/demos/readonly.vue
@@ -11,9 +11,9 @@ onMounted(() => {
     editor = new FluentEditor('#editor-readonly', {
       theme: 'snow',
       modules: {
-        toolbar: false
+        toolbar: false,
       },
-      readOnly: true
+      readOnly: true,
     })
   })
 })

--- a/packages/docs/fluent-editor/docs/demo/readonly.md
+++ b/packages/docs/fluent-editor/docs/demo/readonly.md
@@ -1,0 +1,6 @@
+# 只读模式
+
+通过配置 `modules.toolbar` 为 false 可以隐藏工具栏，配置 `readOnly` 为 true 可以设置只读模式。
+
+:::demo src=demos/readonly.vue
+:::


### PR DESCRIPTION
# PR

效果如下：

![image](https://github.com/user-attachments/assets/32a9818c-f02e-48a5-a955-e15020df2aeb)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our Commit Message Guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added documentation for read-only mode in Fluent Editor
  - Introduced a new sidebar link for read-only mode documentation

- **Documentation**
  - Created a new demo component showcasing read-only editor functionality
  - Added instructions on how to configure toolbar and read-only settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->