### PR TITLE
fix(i18n): toolbar header 未进行国际化翻译 (close #285)

### DIFF
--- a/packages/docs/fluent-editor/demos/i18n.vue
+++ b/packages/docs/fluent-editor/demos/i18n.vue
@@ -15,6 +15,12 @@ onMounted(() => {
       theme: 'snow',
       modules: {
         toolbar: [
+          [
+            { header: [] },
+            { font: [] },
+            { size: [] },
+            { 'line-height': [] },
+          ],
           ['bold', 'italic', 'strike', 'underline'],
           ['link', 'image', 'emoji'],
           [{ color: [] }, { background: [] }],

--- a/packages/fluent-editor/src/themes/snow.ts
+++ b/packages/fluent-editor/src/themes/snow.ts
@@ -177,7 +177,9 @@ class SnowTheme extends OriginSnowTheme {
     const toolbar = this.quill.getModule('toolbar') as TypeToolbar
     ColorPicker.clearText = this.quill.getLangText('clear-color')
     ColorPicker.customText = this.quill.getLangText('custom-color')
+
     if (!toolbar || !this.pickers) return
+
     this.pickers.forEach((picker) => {
       if (picker instanceof ColorPicker) {
         // EasyColorPicker have not dts. abd origin quill ColorPicker dts not complete. use any to resovle ts type error
@@ -190,6 +192,24 @@ class SnowTheme extends OriginSnowTheme {
         })
         colorPicker.buildOptions()
         colorPicker.createUsedColor()
+      }
+
+      if (picker.select && picker.select.classList.contains('ql-header')) {
+        const select = picker.select as HTMLSelectElement
+
+        Array.from(select.options).forEach((option) => {
+          const value = option.getAttribute('value')
+          const trText = this.quill.getLangText(value ? `h${value}` : 'normal')
+
+          if (option.getAttribute('selected')) {
+            picker.label.setAttribute('data-label', trText)
+          }
+
+          option.textContent = trText
+        })
+
+        picker.options.remove()
+        picker.buildOptions()
       }
     })
   }


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our Commit Message Guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

toolbar header 切换中文后仍显示英文

Issue Number: #285 

## What is the new behavior?

<img width="842" height="355" alt="image" src="https://github.com/user-attachments/assets/13a6e191-e8cb-4bbb-9d43-cd25fd1df9f4" />

中英文可以正确切换

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

已知问题
1. 第一次选择选项，select 显示未正确更新，从 a 切换到 b 仍显示 a，第二次切换后正常
2. 切换语言后，选项选中状态会重置，待寻找解决办法


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Header formatting options in the Snow theme toolbar are now fully localized (e.g., H1/H2/H3/Normal), including the picker’s displayed label.
- Documentation
  - i18n demo updated to showcase an expanded text-formatting toolbar group (Header, Font, Size, Line Height) placed before bold/italic/underline, making these options more discoverable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->