### PR TITLE
fix: fix image paste position error

### DIFF
--- a/packages/fluent-editor/src/modules/custom-clipboard.ts
+++ b/packages/fluent-editor/src/modules/custom-clipboard.ts
@@ -161,8 +161,10 @@ export class CustomClipboard extends Clipboard {
 
       setTimeout(() => {
         this.quill.updateContents(delta, Quill.sources.USER)
+        // 光标位置应该在粘贴内容之后：原光标位置 + 粘贴内容长度
+        const newSelectionIndex = linePos.index + (pastedContent.length ? pastedContent.length() : 0)
         this.quill.setSelection(
-          delta.length() - linePos.length - linePos.fix,
+          newSelectionIndex,
           Quill.sources.SILENT,
         )
         this.quill.scrollSelectionIntoView()
@@ -390,6 +392,10 @@ export class CustomClipboard extends Clipboard {
       }
       if (typeof op.insert === 'string') {
         length += op.insert.length
+      }
+      else if (typeof op.insert === 'object') {
+        // 对于图片、提及等对象类型的 insert，长度为 1
+        length += 1
       }
       return true
     })


### PR DESCRIPTION
# PR

close #441 #402 

before:

![TinyEditor粘贴图片-before](https://github.com/user-attachments/assets/aa8f86ad-e5a5-4040-9e5a-03d117fdf6ce)

after:

![TinyEditor粘贴图片-after](https://github.com/user-attachments/assets/70dcc91a-41b3-4231-b172-30e7167f7a09)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our Commit Message Guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cursor positioning after pasting content; the cursor now correctly moves to the end of pasted material
  * Enhanced handling of non-text content pastes (images, mentions) with accurate cursor placement calculations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->