### PR TITLE
fix: avoid exposing all system env vars in Vite define config

### DIFF
--- a/packages/docs/fluent-editor/vite.config.ts
+++ b/packages/docs/fluent-editor/vite.config.ts
@@ -18,6 +18,11 @@ export default defineConfig({
     ],
   },
   define: {
-    'process.env': { ...process.env },
+    'process.env': {
+      npm_package_devDependencies_vite: process.env.npm_package_devDependencies_vite,
+      npm_package_devDependencies_vitepress: process.env.npm_package_devDependencies_vitepress,
+      npm_package_dependencies_vue: process.env.npm_package_dependencies_vue,
+      npm_package_dependencies_quill: process.env.npm_package_dependencies_quill,
+    },
   },
 })


### PR DESCRIPTION
## Summary
- Replace `'process.env': { ...process.env }` in `vite.config.ts` with only the 4 `npm_package_*` variables actually consumed by `insert-deps-version.ts` in the browser
- Prevents leaking unnecessary system environment variables (API keys, tokens, paths, etc.) into the client-side bundle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to explicitly manage environment variable exposure.

**Note:** This is an internal configuration adjustment with no user-facing changes or new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->